### PR TITLE
Fix #58: preserve month in datetime labels when day and time both change

### DIFF
--- a/R/labels-datetime.R
+++ b/R/labels-datetime.R
@@ -115,8 +115,16 @@ collapse_datetime_label <- function(
   if (!any(differs)) return(full)
 
   diff_rank <- min(ranks[differs])
+  collapse_rank <- diff_rank
+
+  # If both day and time differ, keep month with both endpoints so that
+  # day labels remain anchored to a month (issue #58).
+  if (diff_rank == 3 && any(differs & ranks > diff_rank)) {
+    collapse_rank <- 2
+  }
+
   higher_differs <- comparable & (ranks < diff_rank) & (l_tokens != r_tokens)
-  active_components <- which(comparable & (ranks >= diff_rank))
+  active_components <- which(comparable & (ranks >= collapse_rank))
 
   if (any(higher_differs) || length(active_components) == 0 || diff_rank == 1) {
     return(full)

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -518,3 +518,15 @@ test_that("lbl_date collapses around first differing component", {
   )
 })
 
+
+test_that("lbl_datetime keeps month when both day and time differ", {
+  brk <- brk_res(brk_default(as.POSIXct(c(
+    "2020-05-30 22:00:00",
+    "2020-05-31 02:00:00"
+  ), tz = "UTC")))
+
+  expect_equal(
+    lbl_datetime(fmt = "%H:%M %d %b", unit = NULL)(brk),
+    "22:00 30 May-02:00 31 May"
+  )
+})


### PR DESCRIPTION
### Motivation
- Labels produced by `lbl_datetime()` could drop month context on the left endpoint when the first differing component was day but time also differed (issue #58), producing confusing labels across midnight within the same month.

### Description
- Update `collapse_datetime_label()` in `R/labels-datetime.R` to introduce a `collapse_rank` that is widened to the month level when `diff_rank == 3` (day) and there are also time differences, so month tokens are preserved on both endpoints.
- Adjust the active component selection to use `collapse_rank` instead of `diff_rank` and add a regression test in `tests/testthat/test-labels.R` that asserts the label for a midnight-crossing interval is `"22:00 30 May-02:00 31 May"`.

### Testing
- Ran `pkgload::load_all("."); testthat::test_file("tests/testthat/test-labels.R")`, which passed the new regression test along with existing `test-labels.R` tests (tests ran and passed in the local environment except for a benign deprecation warning reported by `lbl_dash` tests).
- Verified example usage with `pkgload::load_all("."); x <- chop_width(..., labels = lbl_datetime(fmt = "%H:%M %d %b")); print(levels(x))` produced the expected levels including `"22:00 30 May-02:00 31 May"`.
- Note: `devtools::test()` in this environment reported "No test files found" due to project test discovery differences, so targeted `testthat::test_file()` was used for automated verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08c9ace3c8330ae6dc7282e234de4)