### PR TITLE
Add weights to mean-SD chopping

### DIFF
--- a/R/breaks-misc.R
+++ b/R/breaks-misc.R
@@ -109,7 +109,7 @@ brk_pretty <- function (n = 5, ...) {
 #' @export
 #' @order 2
 #' @importFrom lifecycle deprecated
-brk_mean_sd <- function (sds = 1:3, sd = deprecated(), weights = NULL) {
+brk_mean_sd <- function (sds = 1:3, weights = NULL, sd = deprecated()) {
   if (lifecycle::is_present(sd)) {
     lifecycle::deprecate_warn(
             when = "0.7.0",

--- a/R/breaks-misc.R
+++ b/R/breaks-misc.R
@@ -123,13 +123,14 @@ brk_mean_sd <- function (sds = 1:3, sd = deprecated(), weights = NULL) {
     if (! sd %in% sds) sds <- c(sds, sd)
   }
 
-  assert_that(
-    is.numeric(sds),
-    all(sds > 0),
-    is.null(weights) || is.numeric(weights),
-    is.null(weights) || all(weights >= 0, na.rm = TRUE),
-    is.null(weights) || all(is.finite(weights) | is.na(weights))
-  )
+  assert_that(is.numeric(sds), all(sds > 0))
+  if (! is.null(weights)) {
+    assert_that(
+      is.numeric(weights),
+      all(weights >= 0, na.rm = TRUE),
+      all(is.finite(weights) | is.na(weights))
+    )
+  }
 
   function (x, extend, left, close_end) {
     if (is.null(weights)) {
@@ -140,17 +141,16 @@ brk_mean_sd <- function (sds = 1:3, sd = deprecated(), weights = NULL) {
       rlang::check_installed("Hmisc",
                              reason = "to use `weights` in brk_mean_sd()")
 
-      keep <- ! is.na(x) & ! is.na(weights) & weights > 0
-      x_stats <- x[keep]
-      weights_stats <- weights[keep]
-      x_mean <- stats::weighted.mean(x_stats, weights_stats)
-      x_sd <- if (sum(weights_stats) <= 1) {
+      x_stats <- x
+      x_stats[is.na(weights) | weights == 0] <- NA
+      x_mean <- stats::weighted.mean(x_stats, weights, na.rm = TRUE)
+      x_sd <- if (sum(weights[! is.na(x_stats)], na.rm = TRUE) <= 1) {
         NA_real_
       } else {
         sqrt(Hmisc::wtd.var(
           strict_as_numeric(x_stats),
-          weights = weights_stats,
-          na.rm = FALSE
+          weights = weights,
+          na.rm = TRUE
         ))
       }
     }

--- a/R/breaks-misc.R
+++ b/R/breaks-misc.R
@@ -109,7 +109,7 @@ brk_pretty <- function (n = 5, ...) {
 #' @export
 #' @order 2
 #' @importFrom lifecycle deprecated
-brk_mean_sd <- function (sds = 1:3, sd = deprecated()) {
+brk_mean_sd <- function (sds = 1:3, sd = deprecated(), weights = NULL) {
   if (lifecycle::is_present(sd)) {
     lifecycle::deprecate_warn(
             when = "0.7.0",
@@ -123,11 +123,37 @@ brk_mean_sd <- function (sds = 1:3, sd = deprecated()) {
     if (! sd %in% sds) sds <- c(sds, sd)
   }
 
-  assert_that(is.numeric(sds), all(sds > 0))
+  assert_that(
+    is.numeric(sds),
+    all(sds > 0),
+    is.null(weights) || is.numeric(weights),
+    is.null(weights) || all(weights >= 0, na.rm = TRUE),
+    is.null(weights) || all(is.finite(weights) | is.na(weights))
+  )
 
   function (x, extend, left, close_end) {
-    x_mean <- mean(x, na.rm = TRUE)
-    x_sd <- stats::sd(x, na.rm = TRUE)
+    if (is.null(weights)) {
+      x_mean <- mean(x, na.rm = TRUE)
+      x_sd <- stats::sd(x, na.rm = TRUE)
+    } else {
+      assert_that(length(weights) == length(x))
+      rlang::check_installed("Hmisc",
+                             reason = "to use `weights` in brk_mean_sd()")
+
+      keep <- ! is.na(x) & ! is.na(weights) & weights > 0
+      x_stats <- x[keep]
+      weights_stats <- weights[keep]
+      x_mean <- stats::weighted.mean(x_stats, weights_stats)
+      x_sd <- if (sum(weights_stats) <= 1) {
+        NA_real_
+      } else {
+        sqrt(Hmisc::wtd.var(
+          strict_as_numeric(x_stats),
+          weights = weights_stats,
+          na.rm = FALSE
+        ))
+      }
+    }
 
     if (is.na(x_mean) || is.na(x_sd) || x_sd == 0) {
       return(empty_breaks())

--- a/R/breaks-misc.R
+++ b/R/breaks-misc.R
@@ -144,12 +144,13 @@ brk_mean_sd <- function (sds = 1:3, sd = deprecated(), weights = NULL) {
       x_stats <- x
       x_stats[is.na(weights) | weights == 0] <- NA
       x_mean <- stats::weighted.mean(x_stats, weights, na.rm = TRUE)
-      x_sd <- if (sum(weights[! is.na(x_stats)], na.rm = TRUE) <= 1) {
+      x_sd <- if (sum(! is.na(x_stats)) <= 1) {
         NA_real_
       } else {
         sqrt(Hmisc::wtd.var(
           strict_as_numeric(x_stats),
           weights = weights,
+          normwt = TRUE,
           na.rm = TRUE
         ))
       }

--- a/R/chop-misc.R
+++ b/R/chop-misc.R
@@ -10,12 +10,8 @@
 #' `chop_mean_sd(x, sds = 1:3)` instead of `chop_mean_sd(x, sd = 3)`.
 #'
 #' @param sds Positive numeric vector of standard deviations.
-#' @param weights `NULL` or a non-negative numeric vector of the same length as
-#'   `x`. Weights are treated as sampling weights and normalized to sum to the
-#'   number of non-missing observations. Multiplying all weights by a constant
-#'   does not affect the result. Missing values in `x` or `weights`, and values
-#'   with zero weight, are omitted when calculating the mean and standard
-#'   deviation.
+#' @param weights Optional weights for the mean/sd calculation. Weights are
+#'   normalized to sum to `length(x)`.
 #' @param sd  `r lifecycle::badge("deprecated")`
 #'
 #' @inheritParams chop

--- a/R/chop-misc.R
+++ b/R/chop-misc.R
@@ -42,7 +42,7 @@ chop_mean_sd <- function (
                   weights = NULL,
                   sd  = deprecated()
                 ) {
-  chop(x, brk_mean_sd(sds = sds, sd = sd, weights = weights), ..., raw = raw)
+  chop(x, brk_mean_sd(sds = sds, weights = weights, sd = sd), ..., raw = raw)
 }
 
 

--- a/R/chop-misc.R
+++ b/R/chop-misc.R
@@ -10,6 +10,10 @@
 #' `chop_mean_sd(x, sds = 1:3)` instead of `chop_mean_sd(x, sd = 3)`.
 #'
 #' @param sds Positive numeric vector of standard deviations.
+#' @param weights `NULL` or a non-negative numeric vector of the same length as
+#'   `x`. Weights are treated as frequency weights. Missing values in `x` or
+#'   `weights`, and values with zero weight, are omitted when calculating the
+#'   mean and standard deviation.
 #' @param sd  `r lifecycle::badge("deprecated")`
 #'
 #' @inheritParams chop
@@ -23,6 +27,8 @@
 #' @examples
 #' chop_mean_sd(1:10)
 #'
+#' chop_mean_sd(1:4, weights = 1:4)
+#'
 #' chop(1:10, brk_mean_sd())
 #'
 #' @importFrom lifecycle deprecated
@@ -31,9 +37,10 @@ chop_mean_sd <- function (
                   sds = 1:3,
                   ...,
                   raw = FALSE,
+                  weights = NULL,
                   sd  = deprecated()
                 ) {
-  chop(x, brk_mean_sd(sds = sds, sd = sd), ..., raw = raw)
+  chop(x, brk_mean_sd(sds = sds, sd = sd, weights = weights), ..., raw = raw)
 }
 
 
@@ -103,4 +110,3 @@ chop_fn <- function (
   chop(x, brk_fn(fn, ...), extend = extend, left = left, close_end = close_end,
          raw = raw, drop = drop)
 }
-

--- a/R/chop-misc.R
+++ b/R/chop-misc.R
@@ -11,9 +11,11 @@
 #'
 #' @param sds Positive numeric vector of standard deviations.
 #' @param weights `NULL` or a non-negative numeric vector of the same length as
-#'   `x`. Weights are treated as frequency weights. Missing values in `x` or
-#'   `weights`, and values with zero weight, are omitted when calculating the
-#'   mean and standard deviation.
+#'   `x`. Weights are treated as sampling weights and normalized to sum to the
+#'   number of non-missing observations. Multiplying all weights by a constant
+#'   does not affect the result. Missing values in `x` or `weights`, and values
+#'   with zero weight, are omitted when calculating the mean and standard
+#'   deviation.
 #' @param sd  `r lifecycle::badge("deprecated")`
 #'
 #' @inheritParams chop

--- a/man/chop_mean_sd.Rd
+++ b/man/chop_mean_sd.Rd
@@ -6,9 +6,9 @@
 \alias{tab_mean_sd}
 \title{Chop by standard deviations}
 \usage{
-chop_mean_sd(x, sds = 1:3, ..., raw = FALSE, sd = deprecated())
+chop_mean_sd(x, sds = 1:3, ..., raw = FALSE, weights = NULL, sd = deprecated())
 
-brk_mean_sd(sds = 1:3, sd = deprecated())
+brk_mean_sd(sds = 1:3, sd = deprecated(), weights = NULL)
 
 tab_mean_sd(x, sds = 1:3, ..., raw = FALSE)
 }
@@ -20,6 +20,11 @@ tab_mean_sd(x, sds = 1:3, ..., raw = FALSE)
 \item{...}{Passed to \code{\link[=chop]{chop()}}.}
 
 \item{raw}{Logical. Use raw values in labels?}
+
+\item{weights}{\code{NULL} or a non-negative numeric vector of the same length as
+\code{x}. Weights are treated as frequency weights. Missing values in \code{x} or
+\code{weights}, and values with zero weight, are omitted when calculating the
+mean and standard deviation.}
 
 \item{sd}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 }
@@ -41,6 +46,8 @@ To chop 1, 2 and 3 standard deviations around the mean, write
 }
 \examples{
 chop_mean_sd(1:10)
+
+chop_mean_sd(1:4, weights = 1:4)
 
 chop(1:10, brk_mean_sd())
 

--- a/man/chop_mean_sd.Rd
+++ b/man/chop_mean_sd.Rd
@@ -22,9 +22,11 @@ tab_mean_sd(x, sds = 1:3, ..., raw = FALSE)
 \item{raw}{Logical. Use raw values in labels?}
 
 \item{weights}{\code{NULL} or a non-negative numeric vector of the same length as
-\code{x}. Weights are treated as frequency weights. Missing values in \code{x} or
-\code{weights}, and values with zero weight, are omitted when calculating the
-mean and standard deviation.}
+\code{x}. Weights are treated as sampling weights and normalized to sum to the
+number of non-missing observations. Multiplying all weights by a constant
+does not affect the result. Missing values in \code{x} or \code{weights}, and values
+with zero weight, are omitted when calculating the mean and standard
+deviation.}
 
 \item{sd}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 }

--- a/man/chop_mean_sd.Rd
+++ b/man/chop_mean_sd.Rd
@@ -21,12 +21,8 @@ tab_mean_sd(x, sds = 1:3, ..., raw = FALSE)
 
 \item{raw}{Logical. Use raw values in labels?}
 
-\item{weights}{\code{NULL} or a non-negative numeric vector of the same length as
-\code{x}. Weights are treated as sampling weights and normalized to sum to the
-number of non-missing observations. Multiplying all weights by a constant
-does not affect the result. Missing values in \code{x} or \code{weights}, and values
-with zero weight, are omitted when calculating the mean and standard
-deviation.}
+\item{weights}{Optional weights for the mean/sd calculation. Weights are
+normalized to sum to \code{length(x)}.}
 
 \item{sd}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 }

--- a/man/chop_mean_sd.Rd
+++ b/man/chop_mean_sd.Rd
@@ -8,7 +8,7 @@
 \usage{
 chop_mean_sd(x, sds = 1:3, ..., raw = FALSE, weights = NULL, sd = deprecated())
 
-brk_mean_sd(sds = 1:3, sd = deprecated(), weights = NULL)
+brk_mean_sd(sds = 1:3, weights = NULL, sd = deprecated())
 
 tab_mean_sd(x, sds = 1:3, ..., raw = FALSE)
 }

--- a/tests/testthat/test-Date-DateTime.R
+++ b/tests/testthat/test-Date-DateTime.R
@@ -79,11 +79,15 @@ test_that("chop_mean_sd", {
   expect_equal(table_vals(res3), table_vals(cmp3), ignore_attr = TRUE)
 
   weights <- seq_along(d1)
-  expanded_d1 <- rep(d1, weights)
   expect_silent(res4 <- chop_mean_sd(d1, weights = weights))
+  weighted_sd <- sqrt(Hmisc::wtd.var(
+    as.numeric(d1),
+    weights = weights,
+    normwt = TRUE
+  ))
   cmp4 <- cut(
     d1,
-    weighted.mean(d1, weights) + c(-10, -2:2) * sd(expanded_d1),
+    weighted.mean(d1, weights) + c(-10, -2:2) * weighted_sd,
     right = FALSE
   )
   expect_equal(table_vals(res4), table_vals(cmp4), ignore_attr = TRUE)

--- a/tests/testthat/test-Date-DateTime.R
+++ b/tests/testthat/test-Date-DateTime.R
@@ -81,11 +81,11 @@ test_that("chop_mean_sd", {
   weights <- seq_along(d1)
   expanded_d1 <- rep(d1, weights)
   expect_silent(res4 <- chop_mean_sd(d1, weights = weights))
-  cmp4 <- droplevels(cut(
+  cmp4 <- cut(
     d1,
-    weighted.mean(d1, weights) + c(-10, -2:2, 10) * sd(expanded_d1),
+    weighted.mean(d1, weights) + c(-10, -2:2) * sd(expanded_d1),
     right = FALSE
-  ))
+  )
   expect_equal(table_vals(res4), table_vals(cmp4), ignore_attr = TRUE)
 })
 

--- a/tests/testthat/test-Date-DateTime.R
+++ b/tests/testthat/test-Date-DateTime.R
@@ -77,6 +77,16 @@ test_that("chop_mean_sd", {
   # the -10 and 10 capture values outside 1.4 sds:
   cmp3 <- cut(d1,  mean(d1) + c(-10, -1.4, -1, 0, 1, 1.4, 10) * sd(d1), right = FALSE)
   expect_equal(table_vals(res3), table_vals(cmp3), ignore_attr = TRUE)
+
+  weights <- seq_along(d1)
+  expanded_d1 <- rep(d1, weights)
+  expect_silent(res4 <- chop_mean_sd(d1, weights = weights))
+  cmp4 <- droplevels(cut(
+    d1,
+    weighted.mean(d1, weights) + c(-10, -2:2, 10) * sd(expanded_d1),
+    right = FALSE
+  ))
+  expect_equal(table_vals(res4), table_vals(cmp4), ignore_attr = TRUE)
 })
 
 

--- a/tests/testthat/test-breaks.R
+++ b/tests/testthat/test-breaks.R
@@ -176,30 +176,42 @@ test_that("brk_mean_sd", {
 })
 
 
-test_that("brk_mean_sd supports frequency weights", {
+test_that("brk_mean_sd supports sampling weights", {
   x <- 1:4
   weights <- 1:4
-  expanded_x <- rep(x, weights)
 
   breaks <- brk_res(brk_mean_sd(1:2, weights = weights), x = x)
-  expected <- mean(expanded_x) + c(-2:-1, 0:2) * stats::sd(expanded_x)
+  normalized_weights <- weights / sum(weights)
+  x_mean <- sum(normalized_weights * x)
+  x_sd <- sqrt(
+    sum(normalized_weights * (x - x_mean)^2) /
+      (1 - sum(normalized_weights^2))
+  )
+  expected <- x_mean + c(-2:-1, 0:2) * x_sd
 
   expect_equal(as.numeric(breaks), expected)
+  expect_equal(
+    brk_res(brk_mean_sd(1:2, weights = weights / sum(weights)), x = x),
+    breaks
+  )
   expect_equal(
     brk_res(brk_mean_sd(1:2, weights = rep(1, length(x))), x = x),
     brk_res(brk_mean_sd(1:2), x = x)
   )
 
   missing_weights <- c(1, NA, 0, 2)
-  expanded_x <- rep(x[c(1, 4)], c(1, 2))
   breaks <- brk_res(brk_mean_sd(1, weights = missing_weights), x = x)
-  expected <- mean(expanded_x) + (-1:1) * stats::sd(expanded_x)
-  expect_equal(as.numeric(breaks), expected)
+  expected <- brk_res(brk_mean_sd(1, weights = c(1, 2)), x = x[c(1, 4)])
+  expect_equal(breaks, expected)
 
   expect_silent(
     empty <- brk_res(brk_mean_sd(weights = rep(0, length(x))), x = x)
   )
   expect_equal(as.numeric(empty), c(-Inf, Inf))
+  expect_equal(
+    brk_res(brk_mean_sd(weights = c(0, 1, 0, 0)), x = x),
+    empty
+  )
 
   expect_error(brk_res(brk_mean_sd(weights = 1:3), x = x))
   expect_error(brk_mean_sd(weights = c(1, -1)))

--- a/tests/testthat/test-breaks.R
+++ b/tests/testthat/test-breaks.R
@@ -176,6 +176,37 @@ test_that("brk_mean_sd", {
 })
 
 
+test_that("brk_mean_sd supports frequency weights", {
+  x <- 1:4
+  weights <- 1:4
+  expanded_x <- rep(x, weights)
+
+  breaks <- brk_res(brk_mean_sd(1:2, weights = weights), x = x)
+  expected <- mean(expanded_x) + c(-2:-1, 0:2) * stats::sd(expanded_x)
+
+  expect_equal(as.numeric(breaks), expected)
+  expect_equal(
+    brk_res(brk_mean_sd(1:2, weights = rep(1, length(x))), x = x),
+    brk_res(brk_mean_sd(1:2), x = x)
+  )
+
+  missing_weights <- c(1, NA, 0, 2)
+  expanded_x <- rep(x[c(1, 4)], c(1, 2))
+  breaks <- brk_res(brk_mean_sd(1, weights = missing_weights), x = x)
+  expected <- mean(expanded_x) + (-1:1) * stats::sd(expanded_x)
+  expect_equal(as.numeric(breaks), expected)
+
+  expect_silent(
+    empty <- brk_res(brk_mean_sd(weights = rep(0, length(x))), x = x)
+  )
+  expect_equal(as.numeric(empty), c(-Inf, Inf))
+
+  expect_error(brk_res(brk_mean_sd(weights = 1:3), x = x))
+  expect_error(brk_mean_sd(weights = c(1, -1)))
+  expect_error(brk_mean_sd(weights = c(1, Inf)))
+})
+
+
 test_that("brk_quantiles", {
   expect_silent(brk_res(brk_quantiles(1:3/4)))
 

--- a/tests/testthat/test-breaks.R
+++ b/tests/testthat/test-breaks.R
@@ -190,6 +190,7 @@ test_that("brk_mean_sd supports sampling weights", {
   expected <- x_mean + c(-2:-1, 0:2) * x_sd
 
   expect_equal(as.numeric(breaks), expected)
+  expect_equal(brk_res(brk_mean_sd(1:2, weights), x = x), breaks)
   expect_equal(
     brk_res(brk_mean_sd(1:2, weights = weights / sum(weights)), x = x),
     breaks

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -322,6 +322,14 @@ test_that("chop_mean_sd", {
     factor(c("[-1, 0)", "[0, 1)", "[1, 2)"),
            levels = c("[-1, 0)", "[0, 1)", "[1, 2)"))
   )
+
+  weights <- 1:3
+  expanded_x <- rep(x, weights)
+  weighted_breaks <- mean(expanded_x) + (-1:1) * stats::sd(expanded_x)
+  expect_equal(
+    chop_mean_sd(x, sds = 1, weights = weights, raw = TRUE),
+    chop(x, weighted_breaks, raw = TRUE)
+  )
 })
 
 

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -324,8 +324,9 @@ test_that("chop_mean_sd", {
   )
 
   weights <- 1:3
-  expanded_x <- rep(x, weights)
-  weighted_breaks <- mean(expanded_x) + (-1:1) * stats::sd(expanded_x)
+  weighted_mean <- stats::weighted.mean(x, weights)
+  weighted_sd <- sqrt(Hmisc::wtd.var(x, weights, normwt = TRUE))
+  weighted_breaks <- weighted_mean + (-1:1) * weighted_sd
   expect_equal(
     chop_mean_sd(x, sds = 1, weights = weights, raw = TRUE),
     chop(x, weighted_breaks, raw = TRUE)


### PR DESCRIPTION
## Summary

- add a `weights` argument to `chop_mean_sd()` and `brk_mean_sd()`
- treat weights as sampling weights and normalize them before calculating the sample standard deviation
- make results invariant to multiplying every weight by a constant
- preserve Date and POSIXct support while omitting missing and zero-weight observations
- require at least two positive-weight, non-missing observations
- validate weight lengths and reject negative or infinite weights
- document the new argument and add an example

## Why

`chop_quantiles()` already supports weighted data, but mean/SD-based chopping did not. Sampling weights are the likely use case, so the weighted standard deviation uses `Hmisc::wtd.var(..., normwt = TRUE)`. Equal weights reproduce the unweighted result, and weights normalized to sum to one remain valid.

This calculates descriptive weighted breakpoints. It does not incorporate complex-survey design features such as strata, clusters, or finite-population corrections.

## Validation

- confirmed the original regression test failed before implementation because `brk_mean_sd()` did not accept `weights`
- tests cover the weighted formula, scale invariance, equal weights, missing and zero weights, insufficient effective observations, invalid weights, and Date inputs
- `devtools::test()`: 10,628 passing assertions
- `devtools::check()`: 0 errors, 0 warnings, 0 notes