### PR TITLE
Add cover_tail to chop_width() and friends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # santoku (development version)
 
+* `chop_width()`, `brk_width()` and `tab_width()` gain a `shrink_last` argument
+  to shrink the last interval to the last finite data value (#64).
+
 # santoku 2.0.0
 
 * Breaking change: `chop_quantiles()` with non-null `weights` now normalizes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # santoku (development version)
 
-* `chop_width()`, `brk_width()` and `tab_width()` gain a `shrink_last` argument
-  to shrink the last interval to the last finite data value (#64).
+* `chop_width()`, `brk_width()` and `tab_width()` gain a `cover_tail` argument.
+  Set `cover_tail = FALSE` to handle a final partial interval according to
+  `extend` (#64).
 
 # santoku 2.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # santoku (development version)
 
 * `chop_width()`, `brk_width()` and `tab_width()` gain a `cover_tail` argument.
-  Set `cover_tail = FALSE` to handle a final partial interval according to
-  `extend` (#64).
+  If `cover_tail = FALSE`, the fixed-width breaks don't extend to the final
+  "tail" of the data. This can give nicer breaks, e.g. 
+  `chop_width(1:7, 2, start = 2, cover_tail = FALSE)` will have breaks 
+  `[1, 2), [2, 4), [4, 6), [6, 7]` where  `chop_width(1:7, 2, start = 2)` 
+  gives `[1, 2), [2, 4), [4, 6), [6, 8]`.
+
 
 # santoku 2.0.0
 

--- a/R/breaks-by-width.R
+++ b/R/breaks-by-width.R
@@ -9,8 +9,9 @@
 #'
 #' @param start A scalar of class [Date][base::Dates] or [POSIXct][DateTimeClasses].
 #'   Can be omitted.
-#' @param shrink_last Logical. If `TRUE`, shrink the last interval to the last
-#'   finite value in `x`.
+#' @param cover_tail Logical. If `TRUE`, fixed-width intervals cover all finite
+#'   values in `x`. If `FALSE`, the possible tail is handled according to
+#'   `extend`.
 #'
 #' @details
 #' If `width` is a Period, [`lubridate::add_with_rollback()`][`lubridate::m+`]
@@ -31,12 +32,12 @@ NULL
 #' @rdname chop_width
 #' @export
 #' @order 2
-brk_width <- function (width, start, shrink_last = FALSE) UseMethod("brk_width")
+brk_width <- function (width, start, cover_tail = TRUE) UseMethod("brk_width")
 
 
 #' @rdname brk_width-for-datetime
 #' @export
-brk_width.Duration <- function (width, start, shrink_last = FALSE) {
+brk_width.Duration <- function (width, start, cover_tail = TRUE) {
   loadNamespace("lubridate")
   width <- lubridate::make_difftime(as.numeric(width))
   NextMethod()
@@ -46,9 +47,9 @@ brk_width.Duration <- function (width, start, shrink_last = FALSE) {
 #' @rdname chop_width
 #' @export
 #' @order 2
-brk_width.default <- function (width, start, shrink_last = FALSE) {
+brk_width.default <- function (width, start, cover_tail = TRUE) {
   assert_that(is.scalar(width))
-  assert_that(is.flag(shrink_last), ! is.na(shrink_last))
+  assert_that(is.flag(cover_tail), ! is.na(cover_tail))
 
   sm <- missing(start)
   if (! sm) assert_that(is.scalar(start))
@@ -69,7 +70,9 @@ brk_width.default <- function (width, start, shrink_last = FALSE) {
       return(empty_breaks())
     }
 
-    if (shrink_last) breaks[length(breaks)] <- until
+    if (! cover_tail && breaks[length(breaks)] != until) {
+      breaks <- breaks[-length(breaks)]
+    }
     if (sign(width) <= 0) breaks <- rev(breaks)
 
     breaks <- create_extended_breaks(breaks, x, extend, left, close_end)

--- a/R/breaks-by-width.R
+++ b/R/breaks-by-width.R
@@ -9,9 +9,6 @@
 #'
 #' @param start A scalar of class [Date][base::Dates] or [POSIXct][DateTimeClasses].
 #'   Can be omitted.
-#' @param cover_tail Logical. If `TRUE`, fixed-width intervals cover all finite
-#'   values in `x`. If `FALSE`, the possible tail is handled according to
-#'   `extend`.
 #'
 #' @details
 #' If `width` is a Period, [`lubridate::add_with_rollback()`][`lubridate::m+`]
@@ -36,6 +33,7 @@ brk_width <- function (width, start, cover_tail = TRUE) UseMethod("brk_width")
 
 
 #' @rdname brk_width-for-datetime
+#' @inheritParams chop_width
 #' @export
 brk_width.Duration <- function (width, start, cover_tail = TRUE) {
   loadNamespace("lubridate")

--- a/R/breaks-by-width.R
+++ b/R/breaks-by-width.R
@@ -9,6 +9,8 @@
 #'
 #' @param start A scalar of class [Date][base::Dates] or [POSIXct][DateTimeClasses].
 #'   Can be omitted.
+#' @param shrink_last Logical. If `TRUE`, shrink the last interval to the last
+#'   finite value in `x`.
 #'
 #' @details
 #' If `width` is a Period, [`lubridate::add_with_rollback()`][`lubridate::m+`]
@@ -29,12 +31,12 @@ NULL
 #' @rdname chop_width
 #' @export
 #' @order 2
-brk_width <- function (width, start) UseMethod("brk_width")
+brk_width <- function (width, start, shrink_last = FALSE) UseMethod("brk_width")
 
 
 #' @rdname brk_width-for-datetime
 #' @export
-brk_width.Duration <- function (width, start) {
+brk_width.Duration <- function (width, start, shrink_last = FALSE) {
   loadNamespace("lubridate")
   width <- lubridate::make_difftime(as.numeric(width))
   NextMethod()
@@ -44,8 +46,9 @@ brk_width.Duration <- function (width, start) {
 #' @rdname chop_width
 #' @export
 #' @order 2
-brk_width.default <- function (width, start) {
+brk_width.default <- function (width, start, shrink_last = FALSE) {
   assert_that(is.scalar(width))
+  assert_that(is.flag(shrink_last), ! is.na(shrink_last))
 
   sm <- missing(start)
   if (! sm) assert_that(is.scalar(start))
@@ -66,6 +69,7 @@ brk_width.default <- function (width, start) {
       return(empty_breaks())
     }
 
+    if (shrink_last) breaks[length(breaks)] <- until
     if (sign(width) <= 0) breaks <- rev(breaks)
 
     breaks <- create_extended_breaks(breaks, x, extend, left, close_end)

--- a/R/chop-by-width.R
+++ b/R/chop-by-width.R
@@ -6,6 +6,8 @@
 #' @param width Width of intervals.
 #' @param start Starting point for intervals. By default the smallest
 #'   finite `x` (largest if `width` is negative).
+#' @param shrink_last Logical. If `TRUE`, shrink the last interval to the last
+#'   finite value in `x`.
 #' @inheritParams chop
 #' @inherit chop-doc params return
 #'
@@ -24,6 +26,8 @@
 #'
 #' chop_width(1:10, 2, start = 0)
 #'
+#' chop_width(1:8, 2, shrink_last = TRUE)
+#'
 #' chop_width(1:9, -2)
 #'
 #' chop(1:10, brk_width(2, 0))
@@ -33,9 +37,10 @@ chop_width <- function (
                 width,
                 start,
                 ...,
-                left = sign(width) > 0
+                left = sign(width) > 0,
+                shrink_last = FALSE
               ) {
-  chop(x, brk_width(width, start), ..., left = left)
+  chop(x, brk_width(width, start, shrink_last = shrink_last), ..., left = left)
 }
 
 

--- a/R/chop-by-width.R
+++ b/R/chop-by-width.R
@@ -6,8 +6,9 @@
 #' @param width Width of intervals.
 #' @param start Starting point for intervals. By default the smallest
 #'   finite `x` (largest if `width` is negative).
-#' @param shrink_last Logical. If `TRUE`, shrink the last interval to the last
-#'   finite value in `x`.
+#' @param cover_tail Logical. If `TRUE`, fixed-width intervals cover all finite
+#'   values in `x`. If `FALSE`, the possible tail is handled according to
+#'   `extend`.
 #' @inheritParams chop
 #' @inherit chop-doc params return
 #'
@@ -26,7 +27,7 @@
 #'
 #' chop_width(1:10, 2, start = 0)
 #'
-#' chop_width(1:8, 2, shrink_last = TRUE)
+#' chop_width(1:24, 5, cover_tail = FALSE)
 #'
 #' chop_width(1:9, -2)
 #'
@@ -38,9 +39,9 @@ chop_width <- function (
                 start,
                 ...,
                 left = sign(width) > 0,
-                shrink_last = FALSE
+                cover_tail = TRUE
               ) {
-  chop(x, brk_width(width, start, shrink_last = shrink_last), ..., left = left)
+  chop(x, brk_width(width, start, cover_tail = cover_tail), ..., left = left)
 }
 
 

--- a/R/chop-by-width.R
+++ b/R/chop-by-width.R
@@ -7,8 +7,10 @@
 #' @param start Starting point for intervals. By default the smallest
 #'   finite `x` (largest if `width` is negative).
 #' @param cover_tail Logical. If `TRUE`, fixed-width intervals cover all finite
-#'   values in `x`. If `FALSE`, the possible tail is handled according to
-#'   `extend`.
+#'   values in `x`. If `FALSE`, they go up to the largest `x` value or
+#'   just before it, but not beyond it; any "tail" will then be handled
+#'   by the `extend` argument. (If `width` is negative, the same logic
+#'   applies to the smallest `x`.)
 #' @inheritParams chop
 #' @inherit chop-doc params return
 #'

--- a/R/tab.R
+++ b/R/tab.R
@@ -41,10 +41,12 @@ tab_width <- function (
                width,
                start,
                ...,
-               left = sign(width) > 0
+               left = sign(width) > 0,
+               shrink_last = FALSE
              ) {
   default_table(
-    chop_width(x = x, width = width, start = start, ..., left = left)
+    chop_width(x = x, width = width, start = start, ..., left = left,
+               shrink_last = shrink_last)
   )
 }
 

--- a/R/tab.R
+++ b/R/tab.R
@@ -42,11 +42,11 @@ tab_width <- function (
                start,
                ...,
                left = sign(width) > 0,
-               shrink_last = FALSE
+               cover_tail = TRUE
              ) {
   default_table(
     chop_width(x = x, width = width, start = start, ..., left = left,
-               shrink_last = shrink_last)
+               cover_tail = cover_tail)
   )
 }
 

--- a/man/brk_width-for-datetime.Rd
+++ b/man/brk_width-for-datetime.Rd
@@ -5,7 +5,7 @@
 \alias{brk_width.Duration}
 \title{Equal-width intervals for dates or datetimes}
 \usage{
-\method{brk_width}{Duration}(width, start)
+\method{brk_width}{Duration}(width, start, shrink_last = FALSE)
 }
 \arguments{
 \item{width}{A scalar \link{difftime}, \link[lubridate:Period-class]{Period} or
@@ -13,6 +13,9 @@
 
 \item{start}{A scalar of class \link[base:Dates]{Date} or \link[=DateTimeClasses]{POSIXct}.
 Can be omitted.}
+
+\item{shrink_last}{Logical. If \code{TRUE}, shrink the last interval to the last
+finite value in \code{x}.}
 }
 \description{
 \code{brk_width()} can be used with time interval classes from base R or the

--- a/man/brk_width-for-datetime.Rd
+++ b/man/brk_width-for-datetime.Rd
@@ -15,8 +15,10 @@
 Can be omitted.}
 
 \item{cover_tail}{Logical. If \code{TRUE}, fixed-width intervals cover all finite
-values in \code{x}. If \code{FALSE}, the possible tail is handled according to
-\code{extend}.}
+values in \code{x}. If \code{FALSE}, they go up to the largest \code{x} value or
+just before it, but not beyond it; any "tail" will then be handled
+by the \code{extend} argument. (If \code{width} is negative, the same logic
+applies to the smallest \code{x}.)}
 }
 \description{
 \code{brk_width()} can be used with time interval classes from base R or the

--- a/man/brk_width-for-datetime.Rd
+++ b/man/brk_width-for-datetime.Rd
@@ -5,7 +5,7 @@
 \alias{brk_width.Duration}
 \title{Equal-width intervals for dates or datetimes}
 \usage{
-\method{brk_width}{Duration}(width, start, shrink_last = FALSE)
+\method{brk_width}{Duration}(width, start, cover_tail = TRUE)
 }
 \arguments{
 \item{width}{A scalar \link{difftime}, \link[lubridate:Period-class]{Period} or
@@ -14,8 +14,9 @@
 \item{start}{A scalar of class \link[base:Dates]{Date} or \link[=DateTimeClasses]{POSIXct}.
 Can be omitted.}
 
-\item{shrink_last}{Logical. If \code{TRUE}, shrink the last interval to the last
-finite value in \code{x}.}
+\item{cover_tail}{Logical. If \code{TRUE}, fixed-width intervals cover all finite
+values in \code{x}. If \code{FALSE}, the possible tail is handled according to
+\code{extend}.}
 }
 \description{
 \code{brk_width()} can be used with time interval classes from base R or the

--- a/man/chop_width.Rd
+++ b/man/chop_width.Rd
@@ -28,8 +28,10 @@ finite \code{x} (largest if \code{width} is negative).}
 \item{left}{Logical. Left-closed or right-closed breaks?}
 
 \item{cover_tail}{Logical. If \code{TRUE}, fixed-width intervals cover all finite
-values in \code{x}. If \code{FALSE}, the possible tail is handled according to
-\code{extend}.}
+values in \code{x}. If \code{FALSE}, they go up to the largest \code{x} value or
+just before it, but not beyond it; any "tail" will then be handled
+by the \code{extend} argument. (If \code{width} is negative, the same logic
+applies to the smallest \code{x}.)}
 }
 \value{
 \verb{chop_*} functions return a \code{\link[base:factor]{factor}} of the same length as \code{x}.

--- a/man/chop_width.Rd
+++ b/man/chop_width.Rd
@@ -7,13 +7,13 @@
 \alias{tab_width}
 \title{Chop into fixed-width intervals}
 \usage{
-chop_width(x, width, start, ..., left = sign(width) > 0, shrink_last = FALSE)
+chop_width(x, width, start, ..., left = sign(width) > 0, cover_tail = TRUE)
 
-brk_width(width, start, shrink_last = FALSE)
+brk_width(width, start, cover_tail = TRUE)
 
-\method{brk_width}{default}(width, start, shrink_last = FALSE)
+\method{brk_width}{default}(width, start, cover_tail = TRUE)
 
-tab_width(x, width, start, ..., left = sign(width) > 0, shrink_last = FALSE)
+tab_width(x, width, start, ..., left = sign(width) > 0, cover_tail = TRUE)
 }
 \arguments{
 \item{x}{A vector.}
@@ -27,8 +27,9 @@ finite \code{x} (largest if \code{width} is negative).}
 
 \item{left}{Logical. Left-closed or right-closed breaks?}
 
-\item{shrink_last}{Logical. If \code{TRUE}, shrink the last interval to the last
-finite value in \code{x}.}
+\item{cover_tail}{Logical. If \code{TRUE}, fixed-width intervals cover all finite
+values in \code{x}. If \code{FALSE}, the possible tail is handled according to
+\code{extend}.}
 }
 \value{
 \verb{chop_*} functions return a \code{\link[base:factor]{factor}} of the same length as \code{x}.
@@ -49,7 +50,7 @@ chop_width(1:10, 2)
 
 chop_width(1:10, 2, start = 0)
 
-chop_width(1:8, 2, shrink_last = TRUE)
+chop_width(1:24, 5, cover_tail = FALSE)
 
 chop_width(1:9, -2)
 

--- a/man/chop_width.Rd
+++ b/man/chop_width.Rd
@@ -7,13 +7,13 @@
 \alias{tab_width}
 \title{Chop into fixed-width intervals}
 \usage{
-chop_width(x, width, start, ..., left = sign(width) > 0)
+chop_width(x, width, start, ..., left = sign(width) > 0, shrink_last = FALSE)
 
-brk_width(width, start)
+brk_width(width, start, shrink_last = FALSE)
 
-\method{brk_width}{default}(width, start)
+\method{brk_width}{default}(width, start, shrink_last = FALSE)
 
-tab_width(x, width, start, ..., left = sign(width) > 0)
+tab_width(x, width, start, ..., left = sign(width) > 0, shrink_last = FALSE)
 }
 \arguments{
 \item{x}{A vector.}
@@ -26,6 +26,9 @@ finite \code{x} (largest if \code{width} is negative).}
 \item{...}{Passed to \code{\link[=chop]{chop()}}.}
 
 \item{left}{Logical. Left-closed or right-closed breaks?}
+
+\item{shrink_last}{Logical. If \code{TRUE}, shrink the last interval to the last
+finite value in \code{x}.}
 }
 \value{
 \verb{chop_*} functions return a \code{\link[base:factor]{factor}} of the same length as \code{x}.
@@ -45,6 +48,8 @@ go downwards from \code{start}.
 chop_width(1:10, 2)
 
 chop_width(1:10, 2, start = 0)
+
+chop_width(1:8, 2, shrink_last = TRUE)
 
 chop_width(1:9, -2)
 

--- a/tests/testthat/test-Date-DateTime.R
+++ b/tests/testthat/test-Date-DateTime.R
@@ -208,6 +208,20 @@ test_that("chop_width: Period", {
 })
 
 
+test_that("chop_width: shrink_last with Period and Duration", {
+  skip_if_not_installed("lubridate")
+
+  x <- as.Date("2001-01-01") + 0:9
+  expected_last <- as.Date("2001-01-10")
+
+  period_breaks <- brk_res(brk_width(lubridate::days(4), shrink_last = TRUE), x)
+  duration_breaks <- brk_res(brk_width(lubridate::ddays(4), shrink_last = TRUE), x)
+
+  expect_identical(tail(as.vector(period_breaks), 1), as.numeric(expected_last))
+  expect_identical(tail(as.vector(duration_breaks), 1), as.numeric(expected_last))
+})
+
+
 test_that("chop_width: Period quirks", {
   skip_if_not_installed("lubridate")
   library(lubridate)

--- a/tests/testthat/test-Date-DateTime.R
+++ b/tests/testthat/test-Date-DateTime.R
@@ -208,15 +208,25 @@ test_that("chop_width: Period", {
 })
 
 
-test_that("chop_width: shrink_last with Period and Duration", {
+test_that("chop_width: cover_tail with Period and Duration", {
   skip_if_not_installed("lubridate")
 
   x <- as.Date("2001-01-01") + 0:9
   expected_last <- as.Date("2001-01-10")
 
-  period_breaks <- brk_res(brk_width(lubridate::days(4), shrink_last = TRUE), x)
-  duration_breaks <- brk_res(brk_width(lubridate::ddays(4), shrink_last = TRUE), x)
+  period_breaks <- brk_res(brk_width(lubridate::days(4), cover_tail = FALSE), x)
+  duration_breaks <- brk_res(brk_width(lubridate::ddays(4), cover_tail = FALSE), x)
 
+  expected_fixed_last <- as.numeric(as.Date("2001-01-09"))
+  expect_identical(tail(as.vector(period_breaks), 1), expected_fixed_last)
+  expect_identical(tail(as.vector(duration_breaks), 1), expected_fixed_last)
+
+  period_breaks <- brk_res(
+    brk_width(lubridate::days(4), cover_tail = FALSE), x, extend = NULL
+  )
+  duration_breaks <- brk_res(
+    brk_width(lubridate::ddays(4), cover_tail = FALSE), x, extend = NULL
+  )
   expect_identical(tail(as.vector(period_breaks), 1), as.numeric(expected_last))
   expect_identical(tail(as.vector(duration_breaks), 1), as.numeric(expected_last))
 })

--- a/tests/testthat/test-breaks.R
+++ b/tests/testthat/test-breaks.R
@@ -123,6 +123,11 @@ test_that("brk_width", {
 
   b <- brk_res(brk_width(1), c(NA, 2, 4, NA))
   expect_equal(diff(as.vector(b))[1], 1)
+
+  b <- brk_res(brk_width(2, shrink_last = TRUE), 1:8)
+  expect_identical(as.vector(b), c(1, 3, 5, 7, 8))
+
+  expect_error(brk_width(2, shrink_last = NA))
 })
 
 
@@ -138,6 +143,9 @@ test_that("brk_width, negative width", {
 
   b <- brk_res(brk_width(-2, start = 2.5), 0:4)
   expect_identical(as.vector(b), c(-1.5, 0.5, 2.5))
+
+  b <- brk_res(brk_width(-2, shrink_last = TRUE), 1:8)
+  expect_identical(as.vector(b), c(1, 2, 4, 6, 8))
 })
 
 

--- a/tests/testthat/test-breaks.R
+++ b/tests/testthat/test-breaks.R
@@ -124,10 +124,16 @@ test_that("brk_width", {
   b <- brk_res(brk_width(1), c(NA, 2, 4, NA))
   expect_equal(diff(as.vector(b))[1], 1)
 
-  b <- brk_res(brk_width(2, shrink_last = TRUE), 1:8)
+  b <- brk_res(brk_width(2, cover_tail = FALSE), 1:8)
+  expect_identical(as.vector(b), c(1, 3, 5, 7))
+
+  b <- brk_res(brk_width(2, cover_tail = FALSE), 1:8, extend = NULL)
   expect_identical(as.vector(b), c(1, 3, 5, 7, 8))
 
-  expect_error(brk_width(2, shrink_last = NA))
+  b <- brk_res(brk_width(5, cover_tail = FALSE), 1:21)
+  expect_identical(as.vector(b), c(1, 6, 11, 16, 21))
+
+  expect_error(brk_width(2, cover_tail = NA))
 })
 
 
@@ -144,7 +150,10 @@ test_that("brk_width, negative width", {
   b <- brk_res(brk_width(-2, start = 2.5), 0:4)
   expect_identical(as.vector(b), c(-1.5, 0.5, 2.5))
 
-  b <- brk_res(brk_width(-2, shrink_last = TRUE), 1:8)
+  b <- brk_res(brk_width(-2, cover_tail = FALSE), 1:8)
+  expect_identical(as.vector(b), c(2, 4, 6, 8))
+
+  b <- brk_res(brk_width(-2, cover_tail = FALSE), 1:8, extend = NULL)
   expect_identical(as.vector(b), c(1, 2, 4, 6, 8))
 })
 

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -195,14 +195,18 @@ test_that("chop_width", {
     chop_width(x, 2, 0, labels = lbl_seq("1")),
     factor(c(1, rep(2:4, each = 2), 5, 5, 5))
   )
+  expect_equal(tail(levels(chop_width(1:24, 5)), 1), "[21, 26]")
   expect_equal(
-    levels(chop_width(1:8, 2, shrink_last = TRUE)),
-    c("[1, 3)", "[3, 5)", "[5, 7)", "[7, 8]")
+    levels(chop_width(1:24, 5, cover_tail = FALSE)),
+    c("[1, 6)", "[6, 11)", "[11, 16)", "[16, 21)", "[21, 24]")
   )
   expect_equal(
-    levels(chop_width(1:8, -2, shrink_last = TRUE)),
+    levels(chop_width(1:8, -2, cover_tail = FALSE)),
     c("[1, 2]", "(2, 4]", "(4, 6]", "(6, 8]")
   )
+  no_extend <- chop_width(1:24, 5, cover_tail = FALSE, extend = FALSE)
+  expect_true(all(is.na(tail(no_extend, 3))))
+  expect_false(anyNA(chop_width(1:21, 5, cover_tail = FALSE, extend = FALSE)))
 })
 
 

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -195,6 +195,14 @@ test_that("chop_width", {
     chop_width(x, 2, 0, labels = lbl_seq("1")),
     factor(c(1, rep(2:4, each = 2), 5, 5, 5))
   )
+  expect_equal(
+    levels(chop_width(1:8, 2, shrink_last = TRUE)),
+    c("[1, 3)", "[3, 5)", "[5, 7)", "[7, 8]")
+  )
+  expect_equal(
+    levels(chop_width(1:8, -2, shrink_last = TRUE)),
+    c("[1, 2]", "(2, 4]", "(4, 6]", "(6, 8]")
+  )
 })
 
 

--- a/tests/testthat/test-tab.R
+++ b/tests/testthat/test-tab.R
@@ -25,6 +25,11 @@ test_that("tab_width", {
     table(x = c(rep(c("[0, 2)", "[2, 4)", "[4, 6)", "[6, 8]"), 2)),
             dnn = NULL)
   )
+
+  expect_identical(
+    names(tab_width(1:8, 2, shrink_last = TRUE)),
+    c("[1, 3)", "[3, 5)", "[5, 7)", "[7, 8]")
+  )
 })
 
 

--- a/tests/testthat/test-tab.R
+++ b/tests/testthat/test-tab.R
@@ -27,7 +27,7 @@ test_that("tab_width", {
   )
 
   expect_identical(
-    names(tab_width(1:8, 2, shrink_last = TRUE)),
+    names(tab_width(1:8, 2, cover_tail = FALSE)),
     c("[1, 3)", "[3, 5)", "[5, 7)", "[7, 8]")
   )
 })

--- a/tests/testthat/test-zzz-systematic.R
+++ b/tests/testthat/test-zzz-systematic.R
@@ -32,6 +32,7 @@ test_that("systematic tests", {
     brk_default_hi  = expression(brk_default(5)),
     brk_width       = expression(brk_width(1)),
     brk_width2      = expression(brk_width(1, 0)),
+    brk_width3      = expression(brk_width(2, cover_tail = FALSE)),
     brk_spikes  = expression(brk_spikes(1:3, n = 2)),
     brk_w_difft_day = expression(brk_width(as.difftime(5, units = "days"))),
     brk_w_difft_sec = expression(brk_width(as.difftime(5, units = "secs"))),
@@ -120,6 +121,13 @@ test_that("systematic tests", {
   # extend it, there are no possible intervals:
   should_fail(with(test_df,
           brk_fun %in% c("brk_default_hi", "brk_default_lo") &
+          extend == FALSE
+        ))
+
+  # cover_tail = FALSE leaves one break when all values are the same
+  should_fail(with(test_df,
+          brk_fun == "brk_width3" &
+          names(x) %in% c("same", "one") &
           extend == FALSE
         ))
 

--- a/tests/testthat/test-zzz-systematic.R
+++ b/tests/testthat/test-zzz-systematic.R
@@ -1,4 +1,8 @@
 
+# This runs 10,000 tests by default. On CI, or if
+#   options(santoku.test_everything = TRUE)
+# has been set, it runs all the tests
+
 test_that("systematic tests", {
   x_vals <- list(
     ordinary = 4:1,
@@ -124,19 +128,19 @@ test_that("systematic tests", {
           extend == FALSE
         ))
 
-  # cover_tail = FALSE leaves one break when all values are the same
-  should_fail(with(test_df,
-          brk_fun == "brk_width3" &
-          names(x) %in% c("same", "one") &
-          extend == FALSE
-        ))
-
   # ditto when extend is NULL and there's no non-NA data
   # here we have to fail even though with some data we'd be OK
   should_fail(with(test_df,
                     brk_fun %in% c("brk_default_hi", "brk_default_lo") &
                     names(x) %in% c("all_NAs", "none") &
                     is.na(extend)
+  ))
+
+  # cover_tail = FALSE leaves one break when all values are the same
+  should_fail(with(test_df,
+                   brk_fun == "brk_width3" &
+                     names(x) %in% c("same", "one") &
+                     extend == FALSE
   ))
 
   # raw endpoints get duplicated if multiple quantiles are infinite:
@@ -270,4 +274,3 @@ test_that("systematic tests", {
           ))
   }
 })
-


### PR DESCRIPTION
## Summary

- add `cover_tail = TRUE` to `chop_width()`, `brk_width()`, and `tab_width()`
- with `cover_tail = FALSE`, remove an overshooting final fixed-width break and let the standard `extend` logic handle the remaining tail
- retain exact endpoints when the data range is an exact multiple of `width`
- support negative widths, dates, Periods, and Durations
- document the argument and add regression coverage

Fixes #64

## Testing

- `devtools::test()` (10,667 passing)
- `devtools::check(error_on = "warning", manual = FALSE)` (0 errors, 0 warnings, 0 notes)